### PR TITLE
Saves Player position

### DIFF
--- a/Assets/Scenes/CannonScenes/CannonInfo.unity
+++ b/Assets/Scenes/CannonScenes/CannonInfo.unity
@@ -1538,8 +1538,8 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 2008444259}
-        m_TargetAssemblyTypeName: CannonInfoButton, Assembly-CSharp
-        m_MethodName: LoadScene
+        m_TargetAssemblyTypeName: Button, Assembly-CSharp
+        m_MethodName: LoadMuseumScene
         m_Mode: 5
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1936,11 +1936,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 557674364280803901, guid: e605f7a42b96d6d4abd26aaf71612c48, type: 3}
       propertyPath: m_LocalScale.x
-      value: 2
+      value: 1.5
       objectReference: {fileID: 0}
     - target: {fileID: 557674364280803901, guid: e605f7a42b96d6d4abd26aaf71612c48, type: 3}
       propertyPath: m_LocalScale.y
-      value: 2
+      value: 1.5
       objectReference: {fileID: 0}
     - target: {fileID: 557674364280803901, guid: e605f7a42b96d6d4abd26aaf71612c48, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Scenes/CannonScenes/FailCannon.unity
+++ b/Assets/Scenes/CannonScenes/FailCannon.unity
@@ -743,7 +743,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 1769466465}
         m_TargetAssemblyTypeName: Button, Assembly-CSharp
-        m_MethodName: LoadScene
+        m_MethodName: LoadMuseumScene
         m_Mode: 5
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Assets/Scenes/CannonScenes/WinCannon.unity
+++ b/Assets/Scenes/CannonScenes/WinCannon.unity
@@ -376,7 +376,7 @@ GameObject:
   - component: {fileID: 682960612}
   - component: {fileID: 682960611}
   m_Layer: 5
-  m_Name: Return
+  m_Name: Retry
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -455,7 +455,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument: MuseumTest
+          m_StringArgument: CannonPainting
           m_BoolArgument: 0
         m_CallState: 2
 --- !u!114 &682960612
@@ -509,7 +509,7 @@ GameObject:
   - component: {fileID: 1031529843}
   - component: {fileID: 1031529842}
   m_Layer: 5
-  m_Name: Retry
+  m_Name: Return
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -581,14 +581,14 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 1922202453}
         m_TargetAssemblyTypeName: Button, Assembly-CSharp
-        m_MethodName: LoadScene
+        m_MethodName: LoadMuseumScene
         m_Mode: 5
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument: CannonPainting
+          m_StringArgument: MuseumTest
           m_BoolArgument: 0
         m_CallState: 2
 --- !u!114 &1031529843
@@ -803,7 +803,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: Retry
+  m_Text: Return to Museum
 --- !u!222 &1557298536
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -926,7 +926,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: Return to Museum
+  m_Text: Retry
 --- !u!222 &2036484513
 CanvasRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/MuseumTest.unity
+++ b/Assets/Scenes/MuseumTest.unity
@@ -40841,6 +40841,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   PieceNumber: 0
+  PlayerPos: {x: 8, y: 0, z: 0}
 --- !u!1 &1833057772
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Button.cs
+++ b/Assets/Scripts/Button.cs
@@ -2,11 +2,21 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 
 public class Button : MonoBehaviour
-{
+{   
+    
     // Function to be called when the button is pressed
     public void LoadScene(string sceneName)
     {
         SceneManager.LoadScene(sceneName);
+    }
+
+    //Function to be called when button to return to museum is pressed
+    public void LoadMuseumScene(string sceneName)
+    {
+        SceneManager.LoadScene(sceneName);
+
+        //Set returning bool to true since player is returning from painting
+        MainManager.Instance.isReturning = true;
     }
 }
 

--- a/Assets/Scripts/MainManager.cs
+++ b/Assets/Scripts/MainManager.cs
@@ -9,15 +9,9 @@ public class MainManager : MonoBehaviour
 
     public int PieceNumber;
 
-    void Start()
-    {
-        
-    }
+    public Vector3 PlayerPos;
 
-    void Update()
-    {
-        
-    }
+    public bool isReturning;
 
     //Awake happens one time when the object is created
     private void Awake()
@@ -33,5 +27,8 @@ public class MainManager : MonoBehaviour
         Instance = this;
         //Tells game not to destroy object this is attached to as the scene changes
         DontDestroyOnLoad(gameObject);
+
+        //Bool begins unchecked
+        isReturning = false;
     }
 }

--- a/Assets/Scripts/PaintingSceneSwitch.cs
+++ b/Assets/Scripts/PaintingSceneSwitch.cs
@@ -45,6 +45,13 @@ public class PaintingSceneSwitch : MonoBehaviour
         // Check if the player is in the zone and presses the 'P' key
         if (isInZone && Input.GetKeyDown(KeyCode.P))
         {
+            //Records Player position
+            MainManager.Instance.PlayerPos = transform.position;
+
+            //Player is not returning from painting
+            MainManager.Instance.isReturning = false;
+
+            //Changes scene
             Debug.Log("P key pressed, loading scene: " + sceneToLoad);
             SceneManager.LoadScene(sceneToLoad);
         }

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -22,6 +22,12 @@ public class PlayerMovement : MonoBehaviour
         rb = GetComponent<Rigidbody2D>();
         spr = GetComponent<SpriteRenderer>();
         onGround = true;
+
+        //If Player is returning from a painting, their position will be set to their last spot in the museum
+        if(MainManager.Instance.isReturning == true)
+        {
+            transform.position = MainManager.Instance.PlayerPos;
+        }
     }
 
     // Update is called once per frame


### PR DESCRIPTION
-Player position saves when returning to the museum 
-Main manager reads player position upon entering painting and saves it until return 
-New scene change function for instances where the player returns to the museum